### PR TITLE
adds nation-js

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Will Klein
+Copyright (c) 2018 Will Klein
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,86 +6,88 @@ While primarily frontend focused, I also track events related to Node, software 
 
 ## Open CFPs
 
-Conference                | City                   | Date (m/d)    | CFP Closes (m/d)
-------------------------- | ---------------------- | ------------- | -------------
-[RevolutionConf][42]      | Virginia Beach, VA     | 5/17 - 5/18   | [2/11][43]
-[Front-Trends][67]        | Warsaw, Poland         | 5/24 - 5/25   | [3/31][68]
-[DinosaurJS][71]          | Denver, CO             | 6/21 - 6/22   | [3/15][69] 
-[Nordic.js][65]           | Stockholm, Sweden      | 9/6 - 9/7     | [?/?][66]
+| Conference                | City                   | Date (m/d)    | CFP Closes (m/d) |
+| ------------------------- | ---------------------- | ------------- | ---------------- |
+| [RevolutionConf][42]      | Virginia Beach, VA     | 5/17 - 5/18   | [2/11][43]       |
+| [NationJS][1]             | Washington, DC         | 5/18          | [2/22][74]       |
+| [Front-Trends][67]        | Warsaw, Poland         | 5/24 - 5/25   | [3/31][68]       |
+| [DinosaurJS][71]          | Denver, CO             | 6/21 - 6/22   | [3/15][69]       |
+| [Nordic.js][65]           | Stockholm, Sweden      | 9/6 - 9/7     | [?/?][66]        |
 
 ## 2018 Conferences
 
-Conference                | City                   | Date (m/d)
-------------------------- | ---------------------- | -------------
-[JSConf Asia][64]         | Singapore, Malaysia    | 1/25 - 1/27
-[JSConf Iceland][52]      | Reykjavik, Iceland     | 3/1 - 3/2
-[ReactFest][60]           | London, United Kingdom | 3/9
-[TSConf][73]              | Seattle, WA            | 3/12
-[JSConf Australia][53]    | Melbourne, Australia   | 3/21 - 3/22
-[PerfMatters][72]         | Redwood City, CA       | 3/27 - 3/28
-[Codemotion Rome][62]     | Rome, Italy            | 4/13 - 4/14
-[JSHeroes][50]            | Cluj-Napoca, Romania   | 4/18 - 4/20
-[Codestock][20]           | Knoxville, TN          | 4/20 - 4/21
-[Write the Docs][55]      | Portland, OR           | 5/6 - 5/8
-[OpenVis Conf][58]        | Paris, France          | 5/14 - 5/16
-[RevolutionConf][42]      | Virginia Beach, VA     | 5/17 - 5/18
-[Codemania][49]           | Auckland, New Zealand  | 5/23
-[Front-Trends][67]        | Warsaw, Poland         | 5/24 - 5/25
-[JSConf EU][57]           | Berlin, Germany        | 6/2 - 6/3
-[SyntaxCon][36]           | Charleston, SC         | 6/6 - 6/8
-[Fluent][54]              | San Jose, CA           | 6/12 - 6/14
-[DinosaurJS][71]          | Denver, CO             | 6/21 - 6/22
-[JSConf US][70]           | ?                      | 8/21 - 8/23
-[Nordic.js][65]           | Stockholm, Sweden      | 9/6 - 9/7
+| Conference                | City                   | Date (m/d)  |
+| ------------------------- | ---------------------- | ----------- |
+| [JSConf Asia][64]         | Singapore, Malaysia    | 1/25 - 1/27 |
+| [JSConf Iceland][52]      | Reykjavik, Iceland     | 3/1 - 3/2   |
+| [ReactFest][60]           | London, United Kingdom | 3/9         |
+| [TSConf][73]              | Seattle, WA            | 3/12        |
+| [JSConf Australia][53]    | Melbourne, Australia   | 3/21 - 3/22 |
+| [PerfMatters][72]         | Redwood City, CA       | 3/27 - 3/28 |
+| [Codemotion Rome][62]     | Rome, Italy            | 4/13 - 4/14 |
+| [JSHeroes][50]            | Cluj-Napoca, Romania   | 4/18 - 4/20 |
+| [Codestock][20]           | Knoxville, TN          | 4/20 - 4/21 |
+| [Write the Docs][55]      | Portland, OR           | 5/6 - 5/8   |
+| [OpenVis Conf][58]        | Paris, France          | 5/14 - 5/16 |
+| [RevolutionConf][42]      | Virginia Beach, VA     | 5/17 - 5/18 |
+| [NationJS][1]             | Washington, DC         | 5/18        |
+| [Codemania][49]           | Auckland, New Zealand  | 5/23        |
+| [Front-Trends][67]        | Warsaw, Poland         | 5/24 - 5/25 |
+| [JSConf EU][57]           | Berlin, Germany        | 6/2 - 6/3   |
+| [SyntaxCon][36]           | Charleston, SC         | 6/6 - 6/8   |
+| [Fluent][54]              | San Jose, CA           | 6/12 - 6/14 |
+| [DinosaurJS][71]          | Denver, CO             | 6/21 - 6/22 |
+| [JSConf US][70]           | ?                      | 8/21 - 8/23 |
+| [Nordic.js][65]           | Stockholm, Sweden      | 9/6 - 9/7   |
 
 ## 2017 Conferences
 
-Conference                | City                   | Date (m/d)
-------------------------- | ---------------------- | -------------
-[The Lead Developer][31]  | New York, NY           | 2/21
-[React Conf][39]          | Santa Clara, CA        | 3/13 - 3/14
-[Peers][34]               | Seattle, WA            | 4/26 - 4/28
-[MinneWebCon][33]         | Minneapolis, MN        | 5/1 - 5/2
-[CodeStock][20]           | Knoxville, TN          | 5/5 - 5/6
-[SyntaxCon][36]           | Charleston, SC         | 5/18 - 5/19
-[Self.conference][44]     | Detroit, MI            | 5/19 - 5/20
-[RevolutionConf][2]       | Virginia Beach, VA     | 6/1 - 6/2
-[DinosaurJS][19]          | Denver, CO             | 6/15
-[NEJS][47]                | Omaha, NE              | 7/21
-[Develop Denver][16]      | Denver, CO             | 8/10 - 8/11
-[Midwest JS][21]          | Minneapolis, MN        | 8/16 - 8/18
-[React Rally][24]         | Salt Lake City, UT     | 8/24 - 8/25
-[React Boston][48]        | Boston, MA             | 9/23 - 9/24
-[Strange Loop][27]        | St. Louis, MO          | 9/28 - 9/30
-[Full Stack Toronto][40]  | Toronto, Canada        | 10/23 - 10/24
-[NationJS][1]             | Washington, DC         | 11/30 - 12/1
+| Conference               | City               | Date (m/d)    |
+| ------------------------ | ------------------ | ------------- |
+| [The Lead Developer][31] | New York, NY       | 2/21          |
+| [React Conf][39]         | Santa Clara, CA    | 3/13 - 3/14   |
+| [Peers][34]              | Seattle, WA        | 4/26 - 4/28   |
+| [MinneWebCon][33]        | Minneapolis, MN    | 5/1 - 5/2     |
+| [CodeStock][20]          | Knoxville, TN      | 5/5 - 5/6     |
+| [SyntaxCon][36]          | Charleston, SC     | 5/18 - 5/19   |
+| [Self.conference][44]    | Detroit, MI        | 5/19 - 5/20   |
+| [RevolutionConf][2]      | Virginia Beach, VA | 6/1 - 6/2     |
+| [DinosaurJS][19]         | Denver, CO         | 6/15          |
+| [NEJS][47]               | Omaha, NE          | 7/21          |
+| [Develop Denver][16]     | Denver, CO         | 8/10 - 8/11   |
+| [Midwest JS][21]         | Minneapolis, MN    | 8/16 - 8/18   |
+| [React Rally][24]        | Salt Lake City, UT | 8/24 - 8/25   |
+| [React Boston][48]       | Boston, MA         | 9/23 - 9/24   |
+| [Strange Loop][27]       | St. Louis, MO      | 9/28 - 9/30   |
+| [Full Stack Toronto][40] | Toronto, Canada    | 10/23 - 10/24 |
+| [NationJS][1]            | Washington, DC     | 11/30 - 12/1  |
 
 ## 2016 Conferences
 
-Conference                | City                   | Date (m/d)
-------------------------- | ---------------------- | -------------
-[React.js][30]            | San Francisco, CA      | 2/22 - 2/23
-[DinosaurJS][19]          | Denver, CO             | 5/24
-[EmpireJS][23]            | New York, NY           | 5/26 - 5/27
-[CodeStock][20]           | Knoxville, TN          | 7/15 - 7/16
-[npmCamp][25]             | Oakland, CA            | 7/30
-[CascadiaFest][15]        | Semiahmoo, WA          | 8/3 - 8/5
-[Develop Denver][16]      | Denver, CO             | 8/4 - 8/5
-[Midwest JS][21]          | Minneapolis, MN        | 8/10 - 8/12
-[Abstractions][26]        | Pittsburgh, PA         | 8/18 - 8/20
-[Midwest.io][17]          | Kansas City, MO        | 8/22 - 8/23
-[React Rally][24]         | Salt Lake City, UT     | 8/25 - 8/26
-[NEJS][18]                | Omaha, NE              | 8/26
-[Strange Loop][27]        | St. Louis, MO          | 9/15 - 9/17
-[NationJS][1]             | Washington, DC         | 9/16
-[UtahJS][22]              | Salt Lake City, UT     | 9/16
-[Rocky Mountain Ruby][32] | Denver, CO             | 9/30
-[Full Stack Toronto][11]  | Toronto, Canada        | 10/17 - 10/18
-[Connect.Tech][3]         | Atlanta, GA            | 10/20 - 10/22
-[Thunder Plains][5]       | Oklahoma City, OK      | 11/3 - 11/4
-[EmpireNode][28]          | New York, NY           | 11/7
-[Nodevember][7]           | Nashville, TN          | 11/20 - 11/21
-[Node Interactive NA][13] | Austin, TX             | 11/29 - 12/2
+| Conference                | City               | Date (m/d)    |
+| ------------------------- | ------------------ | ------------- |
+| [React.js][30]            | San Francisco, CA  | 2/22 - 2/23   |
+| [DinosaurJS][19]          | Denver, CO         | 5/24          |
+| [EmpireJS][23]            | New York, NY       | 5/26 - 5/27   |
+| [CodeStock][20]           | Knoxville, TN      | 7/15 - 7/16   |
+| [npmCamp][25]             | Oakland, CA        | 7/30          |
+| [CascadiaFest][15]        | Semiahmoo, WA      | 8/3 - 8/5     |
+| [Develop Denver][16]      | Denver, CO         | 8/4 - 8/5     |
+| [Midwest JS][21]          | Minneapolis, MN    | 8/10 - 8/12   |
+| [Abstractions][26]        | Pittsburgh, PA     | 8/18 - 8/20   |
+| [Midwest.io][17]          | Kansas City, MO    | 8/22 - 8/23   |
+| [React Rally][24]         | Salt Lake City, UT | 8/25 - 8/26   |
+| [NEJS][18]                | Omaha, NE          | 8/26          |
+| [Strange Loop][27]        | St. Louis, MO      | 9/15 - 9/17   |
+| [NationJS][1]             | Washington, DC     | 9/16          |
+| [UtahJS][22]              | Salt Lake City, UT | 9/16          |
+| [Rocky Mountain Ruby][32] | Denver, CO         | 9/30          |
+| [Full Stack Toronto][11]  | Toronto, Canada    | 10/17 - 10/18 |
+| [Connect.Tech][3]         | Atlanta, GA        | 10/20 - 10/22 |
+| [Thunder Plains][5]       | Oklahoma City, OK  | 11/3 - 11/4   |
+| [EmpireNode][28]          | New York, NY       | 11/7          |
+| [Nodevember][7]           | Nashville, TN      | 11/20 - 11/21 |
+| [Node Interactive NA][13] | Austin, TX         | 11/29 - 12/2  |
 
 ## Contributing
 
@@ -151,3 +153,4 @@ Please file an issue or submit a PR, and if it interests me, I'll add it. :)
 [71]: https://twitter.com/dinosaur_js/status/954419446927503361
 [72]: https://perfmattersconf.com/
 [73]: https://tsconf.io/
+[74]: https://www.papercall.io/nationjs2018


### PR DESCRIPTION
This PR:
* Adds NationJS to the Open CFP section
* Adds NationJS to the 2018 Conferences Section
* Updates the license year
* And it looks like Prettier did some formatting without me realizing it
  * Happy to remove that formatting if you want
